### PR TITLE
Hide employees in comboboxes correctly after renaming

### DIFF
--- a/Portierniaktosiedzi/ViewModels/ShellViewModel.cs
+++ b/Portierniaktosiedzi/ViewModels/ShellViewModel.cs
@@ -69,6 +69,7 @@ namespace Portierniaktosiedzi.ViewModels
             {
                 DeletedEmployees.Add(SelectedEmployee);
                 Employees.Remove(SelectedEmployee);
+                ComboBoxEmployees.Refresh();
             }
         }
 


### PR DESCRIPTION
Fixes #34 